### PR TITLE
fix: exclude patterns like *migrations* now match directory names

### DIFF
--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -429,7 +429,14 @@ func shouldIncludeFile(filePath string, includePatterns, excludePatterns []strin
 			}
 		} else {
 			// Simple filename pattern
-			if matched, _ := filepath.Match(pattern, filepath.Base(filePath)); matched {
+			baseName := filepath.Base(filePath)
+			matched, _ := filepath.Match(pattern, baseName)
+			if !matched {
+				// Also check if pattern matches any directory component
+				// This handles cases like "*migrations*" matching "db/migrations/file.go"
+				matched = dirMatchesPattern(filePath, pattern)
+			}
+			if matched {
 				return false
 			}
 		}
@@ -520,6 +527,20 @@ func matchesPathPattern(path, pattern string) bool {
 	// Try standard glob matching on full path
 	matched, _ := filepath.Match(pattern, path)
 	return matched
+}
+
+// dirMatchesPattern checks if any directory component in the path matches a pattern.
+// This allows patterns like "*migrations*" to match "db/migrations/file.go".
+func dirMatchesPattern(path string, pattern string) bool {
+	pathSlash := filepath.ToSlash(path)
+	parts := strings.Split(pathSlash, "/")
+	// Check all components except the last (which is the filename)
+	for i := 0; i < len(parts)-1; i++ {
+		if matched, _ := filepath.Match(pattern, parts[i]); matched {
+			return true
+		}
+	}
+	return false
 }
 
 // isDefaultIgnoredDir checks if a directory should be ignored by default

--- a/internal/processor/should_include_test.go
+++ b/internal/processor/should_include_test.go
@@ -1,0 +1,67 @@
+package processor
+
+import (
+	"testing"
+)
+
+func TestShouldIncludeFile_ExcludePatterns(t *testing.T) {
+	tests := []struct {
+		name            string
+		filePath        string
+		excludePatterns []string
+		want            bool // true = include, false = exclude
+	}{
+		{
+			name:            "migrations dir should be excluded by *migrations*",
+			filePath:        "/project/migrations/001_initial.go",
+			excludePatterns: []string{"*migrations*"},
+			want:            false,
+		},
+		{
+			name:            "db/migrations dir should be excluded by *migrations*",
+			filePath:        "/project/db/migrations/001_initial.go",
+			excludePatterns: []string{"*migrations*"},
+			want:            false,
+		},
+		{
+			name:            "regular file should not be excluded by *migrations*",
+			filePath:        "/project/src/main.go",
+			excludePatterns: []string{"*migrations*"},
+			want:            true,
+		},
+		{
+			name:            "file with migrations in name should be excluded",
+			filePath:        "/project/models/migrations_users.go",
+			excludePatterns: []string{"*migrations*"},
+			want:            false,
+		},
+		{
+			name:            "test file should be excluded by *test*",
+			filePath:        "/project/src/components/Button.test.tsx",
+			excludePatterns: []string{"*test*"},
+			want:            false,
+		},
+		{
+			name:            "test dir should be excluded by *test*",
+			filePath:        "/project/src/tests/Button.tsx",
+			excludePatterns: []string{"*test*"},
+			want:            false,
+		},
+		{
+			name:            "vendor file should be excluded",
+			filePath:        "/project/vendor/package/lib.go",
+			excludePatterns: []string{"vendor/**"},
+			want:            false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldIncludeFile(tt.filePath, nil, tt.excludePatterns)
+			if got != tt.want {
+				t.Errorf("shouldIncludeFile(%q, nil, %v) = %v, want %v", 
+					tt.filePath, tt.excludePatterns, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fix for issue #9: `--exclude *migrations*` ignores directories

**Problem:** When using `--exclude *migrations*`, the pattern only matched filenames containing 'migrations', not directory names like `migrations/` or `db/migrations/`.

**Root cause:** The `shouldIncludeFile()` function in `internal/processor/processor.go` only checked if the pattern matched the file's basename, not the directory components in the path.

**Fix:** Added `dirMatchesPattern()` function that checks if any directory component (excluding the filename) matches the pattern. This allows `*migrations*` to match paths like `db/migrations/file.go`.

### Changes

- `internal/processor/processor.go`: Modified the exclude pattern matching to also check directory components
- `internal/processor/should_include_test.go`: Added test cases for the fix

### Example

Before fix:
- `--exclude *migrations*` would NOT exclude `migrations/001_initial.go`

After fix:
- `--exclude *migrations*` correctly excludes both `migrations/001_initial.go` and `db/migrations/001_initial.go`

Closes #9
